### PR TITLE
49 [DEV] Change Reader behavior

### DIFF
--- a/lagerta/src/main/java/com/epam/lathgertha/subscriber/Reader.java
+++ b/lagerta/src/main/java/com/epam/lathgertha/subscriber/Reader.java
@@ -95,7 +95,7 @@ public class Reader extends Scheduler {
         final List<Long> txIdsToCommit = lead.notifyRead(nodeId, scopes);
 
         if (!txIdsToCommit.isEmpty()) {
-            txIdsToCommit.sort(Comparator.comparingLong(Long::longValue));
+            txIdsToCommit.sort(Long::compareTo);
             commitStrategy.commit(txIdsToCommit, buffer);
             lead.notifyCommitted(txIdsToCommit);
             txIdsToCommit.forEach(buffer::remove);


### PR DESCRIPTION
Sorting transaction scopes read by the consumer before sending to notifyRead method.
Sorting committed ids list before sending to notifyCommitted.